### PR TITLE
Fix: propagate users permissions

### DIFF
--- a/src/WebAPI/AdminAPI.cs
+++ b/src/WebAPI/AdminAPI.cs
@@ -965,6 +965,14 @@ public static class AdminAPI
             role.Data.ModelBlacklist = [.. model_blacklist.Split(',').Select(s => s.Trim()).Where(s => !string.IsNullOrWhiteSpace(s))];
             role.Data.PermissionFlags = [.. permissions.Split(',').Select(s => s.Trim()).Where(s => !string.IsNullOrWhiteSpace(s))];
             Program.Sessions.Save();
+            foreach (User user in Program.Sessions.Users.Values)
+            {
+                if (user.Settings.Roles.Contains(name))
+                {
+                    user.BuildRoles();
+                    user.Save();
+                }
+            }
         }
         return new JObject() { ["success"] = true };
     }

--- a/src/WebAPI/AdminAPI.cs
+++ b/src/WebAPI/AdminAPI.cs
@@ -788,6 +788,7 @@ public static class AdminAPI
             user.Data.PasswordHashed = Utilities.HashPassword(user.UserID, password);
         }
         user.Data.IsPasswordSetByAdmin = true;
+        user.BuildRoles();
         user.Save();
         return new JObject() { ["success"] = true };
     }
@@ -822,6 +823,7 @@ public static class AdminAPI
             }
             user.Settings.TrySetFieldValue(key, obj);
         }
+        user.BuildRoles();
         user.Save();
         return new JObject() { ["success"] = true };
     }
@@ -989,6 +991,15 @@ public static class AdminAPI
                 return new JObject() { ["error"] = "Role removal failed." };
             }
             Program.Sessions.Save();
+        }
+
+        foreach (User user in Program.Sessions.Users.Values)
+        {
+            if (user.Settings.Roles.Contains(name))
+            {
+                user.BuildRoles();
+                user.Save();
+            }
         }
         return new JObject() { ["success"] = true };
     }


### PR DESCRIPTION
Currently, when a user is created with a specific role, the role’s permissions are properly applied. However, if the role’s permissions are later changed, or if the user is reassigned to another role, those updates are not correctly propagated. This happens because permission checks are made against a cached snapshot of the role, which is never updated afterward.

This PR fixes that by ensuring the cache is properly refreshed whenever a role’s permissions or a user’s role assignment changes, so the effective permissions always stay in sync.